### PR TITLE
fix : findBySessionId 사용

### DIFF
--- a/src/main/java/com/study/mindit/domain/chat/application/ChatService.java
+++ b/src/main/java/com/study/mindit/domain/chat/application/ChatService.java
@@ -29,7 +29,7 @@ public class ChatService {
         log.info("=== ChatService.processChatMessage 시작 ===");
         log.info("입력: {}", chatRequestDto);
         
-        return chatRoomRepository.findById(chatRequestDto.getSessionId())
+        return chatRoomRepository.findBySessionId(chatRequestDto.getSessionId())
                 .flatMap(chatRoom -> {
                     log.info("=== ChatRoom 조회 완료. 현재 Step: {} ===", chatRoom.getCurrentStep());
                     
@@ -319,6 +319,6 @@ public class ChatService {
 
     // 특정 채팅방 메시지 목록 조회 - conversation_history 반환
     public Mono<ChatRoom> getChatMessages(String sessionId) {
-        return chatRoomRepository.findById(sessionId);
+        return chatRoomRepository.findBySessionId(sessionId);
     }
 }

--- a/src/main/java/com/study/mindit/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/study/mindit/domain/chat/domain/ChatRoom.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Document(collection = "chat_rooms")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -19,7 +18,7 @@ public class ChatRoom extends BaseDocument {
     @Field("room_type")
     private RoomType roomType;
 
-    @Field("session_type")
+    @Field("session_id")
     private String sessionId;
     
     @Field("conversation_history")
@@ -32,7 +31,8 @@ public class ChatRoom extends BaseDocument {
     
     @Field("temp_selected_situations")
     private List<String> tempSelectedSituations;
-    
+
+
     // 대화 추가 메서드
     public void addConversation(String role, Object content) {
         if (this.conversationHistory == null) {
@@ -49,5 +49,10 @@ public class ChatRoom extends BaseDocument {
     // Step 증가
     public void incrementStep() {
         this.currentStep++;
+    }
+    
+    // 임시 선택된 상황들 설정
+    public void setTempSelectedSituations(List<String> situations) {
+        this.tempSelectedSituations = situations;
     }
 } 

--- a/src/main/java/com/study/mindit/domain/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/study/mindit/domain/chat/domain/repository/ChatRoomRepository.java
@@ -3,7 +3,9 @@ package com.study.mindit.domain.chat.domain.repository;
 import com.study.mindit.domain.chat.domain.ChatRoom;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface ChatRoomRepository extends ReactiveMongoRepository<ChatRoom, String> {
     Flux<ChatRoom> findAll();
+    Mono<ChatRoom> findBySessionId(String sessionId);
 } 


### PR DESCRIPTION
### 📝 관련된 이슈
- #8 

### 📚 주요 변경 사항
- ChatRoom 조회 로직 개선

### 🤔 변경 이유
- 1. ChatRoom 엔티티 필드명 오타 수정
   - `@Field("session_type")` → `@Field("session_id")` 수정
   - MongoDB 컬렉션에 올바른 필드명으로 저장되도록 개선

2. Repository 메서드 변경
   - `chatRoomRepository.findById()` → `chatRoomRepository.findBySessionId()` 변경
   - 적용 위치:
     - `ChatService.processChatMessage()` 
     - `ChatService.getChatMessages()`