### PR TITLE
feat: 채팅방 Step 수정 API 추가 및 response 순서 명시

### DIFF
--- a/src/main/java/com/study/mindit/domain/chat/domain/OBChatRoom.java
+++ b/src/main/java/com/study/mindit/domain/chat/domain/OBChatRoom.java
@@ -48,6 +48,11 @@ public class OBChatRoom extends BaseDocument {
         this.currentStep++;
     }
     
+    // Step 설정 (테스트용)
+    public void setCurrentStep(int step) {
+        this.currentStep = step;
+    }
+    
     // 임시 선택된 상황들 설정
     public void setTempSelectedSituations(List<String> situations) {
         this.tempSelectedSituations = situations;

--- a/src/main/java/com/study/mindit/domain/chat/domain/OBConversation.java
+++ b/src/main/java/com/study/mindit/domain/chat/domain/OBConversation.java
@@ -13,9 +13,9 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class OBConversation {
 
     @Field("role")
-    private String role;  // "user" or "assistant"
+    private String role;
 
     @Field("content")
-    private Object content;  // String 또는 구조화된 객체 모두 허용
+    private Object content;
 }
 

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/request/OBChatRequestDTO_1.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/request/OBChatRequestDTO_1.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class OBChatRequestDTO_1 {
 
     @JsonProperty("user_text")
-    private Object content;  // String 또는 구조화된 객체 모두 허용
+    private Object content;
 
     @JsonProperty("session_id")
     private String sessionId;

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/request/OBConversationDTO.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/request/OBConversationDTO.java
@@ -11,5 +11,5 @@ public class OBConversationDTO {
 
     private String role;
 
-    private Object content;  // String 또는 구조화된 객체 모두 허용
+    private Object content;
 }

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_1.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_1.java
@@ -1,6 +1,8 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +10,10 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@JsonPropertyOrder({
+    "question",
+    "choices"
+})
 @Getter
 @Builder
 @NoArgsConstructor
@@ -17,6 +23,6 @@ public class OBChatResponseDTO_1 {
 
     private List<String> choices;
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 }

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_2.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_2.java
@@ -1,11 +1,16 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonPropertyOrder({
+    "response"
+})
 @Getter
 @Builder
 @NoArgsConstructor
@@ -14,6 +19,6 @@ public class OBChatResponseDTO_2 {
 
     private String response;
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 }

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_3.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_3.java
@@ -1,6 +1,8 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +10,12 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@JsonPropertyOrder({
+    "gratitude_message",
+    "user_pattern_summary",
+    "question",
+    "thought_examples"
+})
 @Getter
 @Builder
 @NoArgsConstructor
@@ -25,6 +33,6 @@ public class OBChatResponseDTO_3 {
     @JsonProperty("thought_examples")
     private List<String> thoughtExamples;
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 }

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_4.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_4.java
@@ -1,18 +1,25 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonPropertyOrder({
+    "user_pattern_summary",
+    "category_message",
+    "encouragement"
+})
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class OBChatResponseDTO_4 {
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 
     @JsonProperty("user_pattern_summary")

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_5.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_5.java
@@ -1,6 +1,8 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,13 +10,18 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@JsonPropertyOrder({
+    "intro_message",
+    "question",
+    "situations"
+})
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class OBChatResponseDTO_5 {
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 
     @JsonProperty("intro_message")

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_6.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_6.java
@@ -1,6 +1,8 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,13 +10,20 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@JsonPropertyOrder({
+    "intro_message",
+    "anxiety_hierarchy",
+    "practice_message",
+    "example_message",
+    "support_message"
+})
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class OBChatResponseDTO_6 {
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 
     @JsonProperty("intro_message")

--- a/src/main/java/com/study/mindit/domain/chat/presentation/OBChatController.java
+++ b/src/main/java/com/study/mindit/domain/chat/presentation/OBChatController.java
@@ -72,4 +72,19 @@ public class OBChatController {
                 .map(chatRoom -> ResponseEntity.ok(chatRoom))
                 .defaultIfEmpty(ResponseEntity.notFound().build());
     }
+    
+    // REST API - 채팅방 Step 설정 (테스트용)
+    @PutMapping("/room/{sessionId}")
+    public Mono<ResponseEntity<java.util.Map<String, Object>>> setStep(
+            @PathVariable String sessionId,
+            @RequestParam int step) {
+        return chatService.setStep(sessionId, step)
+                .map(chatRoom -> ResponseEntity.ok(
+                        java.util.Map.<String, Object>of(
+                                "session_id", chatRoom.getId(),
+                                "message", "Step이 " + chatRoom.getCurrentStep() + " 단계로 성공적으로 변경되었습니다."
+                        )
+                ))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
 }


### PR DESCRIPTION
### 📝 관련된 이슈
- #8 #12 

### 📚 주요 변경 사항
- 채팅방 Step 설정 API 추가
- 모든 채팅 단계에서 aiResponseDto 전체를 conversation_history에 저장
- session_id 중복 저장 제거
- ResponseDTO JSON 필드 순서 정렬

### 🤔 변경 이유
- 특정 단계만 반복 테스트해야 하는 경우를 위해, 모든 단계를 거치지 않고 원하는 단계로 고정시켜 테스트할 수 있도록 테스트 엔드포인트 구현 
- 일부 필드만 db에 저장되는 문제를 해결하기 위해, sessionId를 뺀 전체 response를 conversation_history에 저장
- responseDTO에 @JsonPropertyOrder 어노테이션을 추가해서 메세지를 순서대로 정렬
