### PR TITLE
fix: 채팅방 Step 수정 시 db의 conversation_history 기록도 같이 수정되도록 변경

### DIFF
--- a/src/main/java/com/study/mindit/domain/chat/domain/OBChatRoom.java
+++ b/src/main/java/com/study/mindit/domain/chat/domain/OBChatRoom.java
@@ -53,6 +53,11 @@ public class OBChatRoom extends BaseDocument {
         this.currentStep = step;
     }
     
+    // 대화 기록 설정
+    public void setConversationHistory(List<OBConversation> conversationHistory) {
+        this.conversationHistory = conversationHistory;
+    }
+    
     // 임시 선택된 상황들 설정
     public void setTempSelectedSituations(List<String> situations) {
         this.tempSelectedSituations = situations;


### PR DESCRIPTION
### 📝 관련된 이슈
- closes #12 

### 📚 주요 변경 사항
- Step 설정 시 conversation_history 자동 정리

### 🤔 변경 이유
- Step만 변경하면 conversation_history와 불일치 발생 (Step 0인데 5단계 대화 기록 남아있음)
  - OBChatRoom에 setConversationHistory() 메서드 추가
  - Step 설정 시 해당 단계까지만 대화 기록 유지하도록 로직 구현
  - step * 2 공식으로 최대 항목 수 계산 (사용자 메시지 + AI 응답 = 2개씩)
