### PR TITLE
fix: Step 응답 구조 개선

### DIFF
--- a/src/main/java/com/study/mindit/domain/chat/application/OBAiService.java
+++ b/src/main/java/com/study/mindit/domain/chat/application/OBAiService.java
@@ -9,8 +9,8 @@ import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_1;
 import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_2;
 import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_3;
 import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_4;
-import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_5;
-import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_6;
+import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_7;
+import com.study.mindit.domain.chat.dto.obsession.response.OBChatResponseDTO_9;
 import com.study.mindit.global.fastApi.FastApiUrls;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -93,12 +93,12 @@ public class OBAiService {
     }
 
     // analyze7 엔드포인트에 요청 (응답 DTO를 ChatResponseDTO_7로 받음)
-    public Mono<OBChatResponseDTO_5> callAnalyze7(String sessionId, List<OBConversationDTO> conversationHistory) {
+    public Mono<OBChatResponseDTO_7> callAnalyze7(String sessionId, List<OBConversationDTO> conversationHistory) {
         OBChatRequestDTO_2 requestBody = OBChatRequestDTO_2.builder()
                 .conversationHistory(conversationHistory)
                 .sessionId(sessionId)
                 .build();
-        return callFastApiEndpoint(fastApiUrls.getAnalyze7(), requestBody, OBChatResponseDTO_5.class);
+        return callFastApiEndpoint(fastApiUrls.getAnalyze7(), requestBody, OBChatResponseDTO_7.class);
     }
 
     // analyze8 엔드포인트에 요청 (응답 DTO를 ChatResponseDTO_2로 받음)
@@ -110,13 +110,13 @@ public class OBAiService {
         return callFastApiEndpoint(fastApiUrls.getAnalyze8(), requestBody, OBChatResponseDTO_2.class);
     }
 
-    // analyze9 엔드포인트에 요청 (응답 DTO를 ChatResponseDTO_6로 받음)
-    public Mono<OBChatResponseDTO_6> callAnalyze9(String sessionId, List<OBConversationDTO> conversationHistory) {
+    // analyze9 엔드포인트에 요청 (응답 DTO를 ChatResponseDTO_9로 받음)
+    public Mono<OBChatResponseDTO_9> callAnalyze9(String sessionId, List<OBConversationDTO> conversationHistory) {
         OBChatRequestDTO_2 requestBody = OBChatRequestDTO_2.builder()
                 .conversationHistory(conversationHistory)
                 .sessionId(sessionId)
                 .build();
-        return callFastApiEndpoint(fastApiUrls.getAnalyze9(), requestBody, OBChatResponseDTO_6.class);
+        return callFastApiEndpoint(fastApiUrls.getAnalyze9(), requestBody, OBChatResponseDTO_9.class);
     }
 
     // 요청과 응답 타입을 범용적으로 처리하는 메서드

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO.java
@@ -1,7 +1,9 @@
 package com.study.mindit.domain.chat.dto.obsession.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +11,22 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@JsonPropertyOrder({
+    "question",
+    "choices",
+    "response",
+    "gratitude_message",
+    "user_pattern_summary",
+    "thought_examples",
+    "category_message",
+    "encouragement",
+    "intro_message",
+    "situations",
+    "anxiety_hierarchy",
+    "practice_message",
+    "example_message",
+    "support_message"
+})
 @Getter
 @Builder
 @NoArgsConstructor
@@ -54,6 +72,6 @@ public class OBChatResponseDTO {
     @JsonProperty("support_message")
     private String supportMessage;
 
-    @JsonProperty("session_id")
+    @JsonIgnore
     private String sessionId;
 }

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_7.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_7.java
@@ -12,16 +12,14 @@ import java.util.List;
 
 @JsonPropertyOrder({
     "intro_message",
-    "anxiety_hierarchy",
-    "practice_message",
-    "example_message",
-    "support_message"
+    "question",
+    "situations"
 })
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class OBChatResponseDTO_6 {
+public class OBChatResponseDTO_7 {
 
     @JsonIgnore
     private String sessionId;
@@ -29,17 +27,11 @@ public class OBChatResponseDTO_6 {
     @JsonProperty("intro_message")
     private String introMessage;
 
-    @JsonProperty("anxiety_hierarchy")
-    private List<OBAnxietyHierarchyDTO> anxietyHierarchy;
+    @JsonProperty("question")
+    private String question;
 
-    @JsonProperty("practice_message")
-    private String practiceMessage;
-
-    @JsonProperty("example_message")
-    private String exampleMessage;
-
-    @JsonProperty("support_message")
-    private String supportMessage;
+    @JsonProperty("situations")
+    private List<String> situations;
 }
 
 

--- a/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_9.java
+++ b/src/main/java/com/study/mindit/domain/chat/dto/obsession/response/OBChatResponseDTO_9.java
@@ -12,14 +12,16 @@ import java.util.List;
 
 @JsonPropertyOrder({
     "intro_message",
-    "question",
-    "situations"
+    "anxiety_hierarchy",
+    "practice_message",
+    "example_message",
+    "support_message"
 })
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class OBChatResponseDTO_5 {
+public class OBChatResponseDTO_9 {
 
     @JsonIgnore
     private String sessionId;
@@ -27,11 +29,17 @@ public class OBChatResponseDTO_5 {
     @JsonProperty("intro_message")
     private String introMessage;
 
-    @JsonProperty("question")
-    private String question;
+    @JsonProperty("anxiety_hierarchy")
+    private List<OBAnxietyHierarchyDTO> anxietyHierarchy;
 
-    @JsonProperty("situations")
-    private List<String> situations;
+    @JsonProperty("practice_message")
+    private String practiceMessage;
+
+    @JsonProperty("example_message")
+    private String exampleMessage;
+
+    @JsonProperty("support_message")
+    private String supportMessage;
 }
 
 


### PR DESCRIPTION
### 📝 관련된 이슈
- #8 

### 📚 주요 변경 사항
- Response DTO 이름 변경
- JSON 응답 필드 순서 정렬
- Flux를 활용한 연속 응답 구현
- Anxiety Hierarchy 자동 생성

### 🤔 변경 이유
- 실제 사용되는 Step에 맞춰 DTO 명명 변경
  - OBChatResponseDTO_5 -> 7
  - OBChatResponseDTO_6 -> 9
  
 -  @JsonPropertyOrder를 사용하여 각 단계의 responseDTO를 정렬했지만, 출력에 반영되지 않는 문제
    - OBChatResponseDTO 통합 응답 DTO에도 동일하게 적용

 - 특정 Step에서 사용자가 한 번의 메시지를 보내면 두 개의 응답이 순차적으로 WebSocket을 통해 전달되도록 구현
   -> processChatMessage 메서드의 반환 타입을 Mono에서 Flux로 변경하여 여러 응답을 순차적으로 반환
   - Step 4와 5 연속 응답
   - Step 6과 7 연속 응답
   
- Step 9에서 anxiety_hierarchy 필드가 비어있을 경우 anxiety_scores 데이터로 자동 생성