### PR TITLE
fix: FastAPI 호출 시 ReadTimeoutException 해결

### DIFF
--- a/src/main/java/com/study/mindit/global/config/WebClientConfig.java
+++ b/src/main/java/com/study/mindit/global/config/WebClientConfig.java
@@ -25,9 +25,9 @@ public class WebClientConfig {
 
         HttpClient httpClient = HttpClient.create(connectionProvider)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
-                .responseTimeout(Duration.ofSeconds(10))
+                .responseTimeout(Duration.ofSeconds(60))
                 .doOnConnected(conn ->
-                        conn.addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS))
+                        conn.addHandlerLast(new ReadTimeoutHandler(60, TimeUnit.SECONDS))
                                 .addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS)));
 
         return WebClient.builder()


### PR DESCRIPTION
### 📝 관련된 이슈
- #8 

### 📚 주요 변경 사항
- WebClient 타임아웃 설정 변경
  - responseTimeout: 10초 → 60초
  - ReadTimeoutHandler: 10초 → 60초
  - WriteTimeoutHandler: 10초 유지

### 🤔 변경 이유
``` java
Caused by: io.netty.handler.timeout.ReadTimeoutException
at io.netty.handler.timeout.ReadTimeoutHandler.readTimedOut
```
- FastAPI의 analyze7 API 호출 중 ReadTimeoutException 발생
  - AI 응답 생성 시간을 고려하여 타임아웃을 60초로 증가
  - 읽기 타임아웃(responseTimeout, ReadTimeoutHandler) 모두 증가
  - 쓰기 타임아웃은 요청 전송 시간이므로 10초 유지
